### PR TITLE
"use `<script>` inside tag" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,40 @@ This guide provides a uniform way to structure your [RiotJS](http://riotjs.com/)
 * easier to cache and serve bundles of code separately.
 
 This guide is inspired by the [AngularJS Style Guide](https://github.com/johnpapa/angular-styleguide) by John Papa.
+
+
+## Table of Contents
+
+* [Use `<script>` inside tag](#use-script-inside-tag)
+
+
+## Use `<script>` inside tag
+
+While Riot supports writing JavaScript inside a tag element [without a `<script>`](http://riotjs.com/guide/#no-script-tag),
+you should **always use `<script>`** around scripting. This is closer to web standards and prevents confusing developers and IDEs. 
+
+**Why?**
+
+* Prevents markup being interpreted as script.
+* Improves IDE support (signals how to interpret).
+* Tells developers where markup stops and scripting starts.
+
+**How?**
+
+```javascript
+/* recommended */
+<my-example>
+	<h1>The year is { this.year }</h1>
+	
+	<script>
+		this.year = (new Date()).getUTCFullYear();
+	</script>
+</my-example>
+
+/* avoid */
+<my-example>
+	<h1>The year is { this.year }</h1>
+	
+	this.year = (new Date()).getUTCFullYear();
+</my-example>
+```

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ you should **always use `<script>`** around scripting. This is closer to web sta
 
 **How?**
 
-```javascript
-/* recommended */
+```html
+<!-- recommended -->
 <my-example>
 	<h1>The year is { this.year }</h1>
 	
@@ -43,7 +43,7 @@ you should **always use `<script>`** around scripting. This is closer to web sta
 	</script>
 </my-example>
 
-/* avoid */
+<!-- avoid -->
 <my-example>
 	<h1>The year is { this.year }</h1>
 	


### PR DESCRIPTION
## Summary

Proposed changes:
- always use `<script>` inside tag.
## Checklist
- [X] The changes only affect or contain one style guide rule or section.
- [X] The changes are in [style guide format](/CONTRIBUTING.md#format).
- [X] The new style guide section has an entry in the [Table of Contents](/README.md#table-of-contents) (only if changes introduce new section).
- [X] The changes can be merged into the target branch without conflicts. 
