### PR TITLE
"use `*.tag.html` extension" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,31 @@ This guide provides a uniform way to structure your [RiotJS](http://riotjs.com/)
 * easier to cache and serve bundles of code separately.
 
 This guide is inspired by the [AngularJS Style Guide](https://github.com/johnpapa/angular-styleguide) by John Papa.
+
+
+## Table of Contents
+
+* [Use `*.tag.html` extension](#use-taghtml-extension)
+
+
+## Use `*.tag.html` extension
+
+Riot introduces a new concept called *tags*, and suggests to use a `*.tag` extension.
+However in essence these tags are simply custom elements containing markup. Therefore you should **use the `*.tag.html` extension**.
+
+### Why?
+
+* Tells developers it's not just HTML, but a Riot tag element.
+* Improves IDE support (signals how to interpret).
+
+### How?
+
+In case of [in-browser compilation](http://riotjs.com/guide/compiler/#in-browser-compilation):
+```html
+<script src="path/to/modules/my-example/my-example.tag.html" type="riot/tag"></script>
+```
+
+In case of [pre-compilation](http://riotjs.com/guide/compiler/#pre-compilation), set the [custom extension](http://riotjs.com/guide/compiler/#custom-extension):
+```bash
+riot --ext tag.html modules/ dist/tags.js
+```


### PR DESCRIPTION
## Summary

Proposed changes:
- add "use `*.tag.html` extension" rule (incl. summary, why and how).
## Checklist
- [x] The changes only affect or contain one style guide rule or section.
- [x] The changes are in [style guide format](/CONTRIBUTING.md#format).
- [X] The new style guide section has an entry in the [Table of Contents](/README.md#table-of-contents) (only if changes introduce new section).
- [X] The changes can be merged into the target branch without conflicts. 
