### PR TITLE
"Module tag names" rule refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,27 +12,44 @@ This guide provides a uniform way to structure your RiotJS code. Making it
 * easier to (re)use build tools you already use.
 * easier to cache and serve bundles of code separately.
 
-This guide is inspired by [AngularJS Style Guide](https://github.com/johnpapa/angular-styleguide) by John Papa.
+This guide is inspired by the [AngularJS Style Guide](https://github.com/johnpapa/angular-styleguide) by John Papa.
+
 
 ## Table of Contents
 
-1. [Component / Tag names](#component-tag-names)
+* [Tag module names](#tag-module-names)
 
-## Component / Tag names
 
-Component or tag names need to be:
+## Tag module names
 
-* **Spec compliant**: [include a hyphen](https://www.w3.org/TR/custom-elements/#concepts).
+A tag module is a specific type of module, containing a Riot tag. 
+
+Each module name must be:
+
 * **Meaningful**: not overspecific, not overly abstract.
 * **Short**: 2 or 3 words.
 * **Pronouncable**: we want to be able talk about them.
-* **`app` namespaced**: using a standard namespace allows easy reuse in other projects
 
-*Why?*: Your `tag`s are custom elements in the document. As such, they need to adhere the spec.
+Tag module names must also be:
 
-```markup
+* **Custom element spec compliant**: [include a hyphen](https://www.w3.org/TR/custom-elements/#concepts), don't use reserved names.
+* **`app-` namespaced**: if very generic and otherwise 1 word, so that it can easily be reused in other projects.
+
+### Why?
+
+* The name is used to communicate about the module. So it must be short, meaningful and pronouncable.
+* The `tag` element is inserted into the DOM. As such, they need to adhere the spec.
+
+### How?
+
+```html
 <!-- recommended -->
 <app-header />
-<app-user-list />
-<app-ui-slider />
+<user-list />
+<range-slider />
+
+<!-- avoid -->
+<btn-group /> <!-- short, but unpronouncable -->
+<ui-slider /> <!-- all tags are ui elements, so is meaningless -->
+<slider /> <!-- not custom element spec compliant --> 
 ```


### PR DESCRIPTION
## Summary

Proposed changes:
- Rename to "Tag module names".
- ToC as unordered list (like master readme).
- Split text into summary + why + how.
- Add (code) examples.
- Nuance `app-` namespace.
## Checklist
- [X] The changes only affect or contain one style guide rule or section.
- [X] The changes are in [style guide format](/CONTRIBUTING.md#format).
- [X] The new style guide section has an entry in the [Table of Contents](/README.md#table-of-contents) (only if changes introduce new section).
- [X] The changes can be merged into the target branch without conflicts. 

…mespace.
