### PR TITLE
change "Tag name as style scope" to "Use tag name as style scope"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This guide is inspired by the [AngularJS Style Guide](https://github.com/johnpap
 * [Use `*.tag.html` extension](#use-taghtml-extension)
 * [Use `<script>` inside tag](#use-script-inside-tag)
 * [Keep tag expressions simple](#keep-tag-expressions-simple)
-* [Tag name as style scope](#tag-name-as-style-scope)
+* [Use tag name as style scope](#use-tag-name-as-style-scope)
 
 
 ## Module based development
@@ -200,7 +200,7 @@ Move complex expressions to tag methods or tag properties.
 ```
 
 
-## Tag name as style scope
+## Use tag name as style scope
 
 Riot tag elements are custom elements which can very well be used as style scope root.
 Alternatively the module name can be used as CSS class namespace.


### PR DESCRIPTION
## Summary

Proposed changes:
- change "Tag name as style scope" to "Use tag name as style scope"
- Use "command" format for this rule, just like all rules after "1 module = 1 directory".
## Checklist
- [X] The changes only affect or contain one style guide rule or section.
- [X] The changes are in [style guide format](/CONTRIBUTING.md#format).
- [X] The new style guide section has an entry in the [Table of Contents](/README.md#table-of-contents) (only if changes introduce new section).
- [X] The changes can be merged into the target branch without conflicts. 
