### PR TITLE
Removed unnecessary line from `tag.parent` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,6 @@ The exception to this rule are anonymous child tags in a [for each loop](http://
 
 <child-tag>
 	<span>{ opts.value }</span> <!-- use value passed by parent -->
-	<script></script>
 </child-tag>
 
 <!-- avoid -->


### PR DESCRIPTION
## Summary

I removed a line from a `tag.parent` example because as far as I can tell it did not need to be there and did not contribute to the example but instead served to distract from it.  :)

Proposed changes:
- One line is removed from the `tag.parent` example

Resolves no existing issue, but hopefully resolves potential distractions from readers.
## Checklist
- [x] The changes only affect or contain one style guide rule or section.
- [ ] The changes are in [style guide format](/CONTRIBUTING.md#format).
  - I do not feel correct checking this, as I feel it does not really apply in this case.
- [ ] The new style guide section has an entry in the [Table of Contents](/README.md#table-of-contents) (only if changes introduce new section).
- [x] The changes can be merged into the target branch without conflicts. 
