### PR TITLE
extend "Avoid fake ES6 syntax" with "No transformation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ add() {
 }
 ```
 
-[Disable transformation of the fake ES6 syntax](http://riotjs.com/guide/compiler/#no-transformation) during pre-compilation by setting `type` to `none`:
+**Tip**: [Disable transformation of the fake ES6 syntax](http://riotjs.com/guide/compiler/#no-transformation) during pre-compilation by setting `type` to `none`:
 
 ```bash
 riot --type none

--- a/README.md
+++ b/README.md
@@ -492,6 +492,12 @@ add() {
 }
 ```
 
+[Disable transformation of the fake ES6 syntax](http://riotjs.com/guide/compiler/#no-transformation) during pre-compilation by setting `type` to `none`:
+
+```bash
+riot --type none
+```
+
 [↑ back to Table of Contents](#table-of-contents)
 
 


### PR DESCRIPTION
## Summary

Proposed changes:
- extend "Avoid fake ES6 syntax" with "No transformation"
- based on http://riotjs.com/guide/compiler/#no-transformation
## Checklist
- [X] The changes only affect or contain one style guide rule or section.
- [X] The changes are in [style guide format](/CONTRIBUTING.md#format).
- [X] The changes can be merged into the target branch without conflicts. 
