### PR TITLE
add "compile modular" to "Module based development"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ If your module does too much or gets too big, split it up into smaller modules w
 As a rule of thumb, try to keep each tag file less than 100 lines of code.
 Also ensure your tag module works in isolation. For instance by adding a stand-alone demo.
 
+If you use an [AMD](https://github.com/amdjs/amdjs-api/blob/master/AMD.md) or CommonJS module loader, you need to [compile your tags using the `--modular` (`-m`) flag](http://riotjs.com/guide/compiler/#amd-and-commonjs):
+```bash
+# enable AMD and CommonJS
+riot --modular
+```
+
 [↑ back to Table of Contents](#table-of-contents)
 
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If your module does too much or gets too big, split it up into smaller modules w
 As a rule of thumb, try to keep each tag file less than 100 lines of code.
 Also ensure your tag module works in isolation. For instance by adding a stand-alone demo.
 
-If you use an [AMD](https://github.com/amdjs/amdjs-api/blob/master/AMD.md) or CommonJS module loader, you need to [compile your tags using the `--modular` (`-m`) flag](http://riotjs.com/guide/compiler/#amd-and-commonjs):
+**Tip**: If you use an [AMD](https://github.com/amdjs/amdjs-api/blob/master/AMD.md) or CommonJS module loader, you need to [compile your tags using the `--modular` (`-m`) flag](http://riotjs.com/guide/compiler/#amd-and-commonjs):
 ```bash
 # enable AMD and CommonJS
 riot --modular


### PR DESCRIPTION
## Summary

Proposed changes:
- add "compile modular" to "Module based development"
- linked to RiotJS guide itself for details of how to use in AMD or CommonJS.

Resolves #46
## Checklist
- [X] The changes only affect or contain one style guide rule or section.
- [X] The changes are in [style guide format](/CONTRIBUTING.md#format).
- [X] The changes can be merged into the target branch without conflicts. 
