### PR TITLE
add "Webpack tag loader config" to "use .tag.html"

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ In case of [pre-compilation](http://riotjs.com/guide/compiler/#pre-compilation),
 riot --ext tag.html modules/ dist/tags.js
 ```
 
+In case your using the [Webpack tag loader](https://github.com/srackham/tag-loader), [configure the loader](http://webpack.github.io/docs/using-loaders.html#configuration) to match the extension:
+```javascript
+{ test: /\.tag.html$/, loader: 'tag' }
+```
+
 [↑ back to Table of Contents](#table-of-contents)
 
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ In case of [pre-compilation](http://riotjs.com/guide/compiler/#pre-compilation),
 riot --ext tag.html modules/ dist/tags.js
 ```
 
-In case your using the [Webpack tag loader](https://github.com/srackham/tag-loader), [configure the loader](http://webpack.github.io/docs/using-loaders.html#configuration) to match the extension:
+In case you're using the [Webpack tag loader](https://github.com/srackham/tag-loader), [configure the loader](http://webpack.github.io/docs/using-loaders.html#configuration) to match the extension:
 ```javascript
 { test: /\.tag.html$/, loader: 'tag' }
 ```


### PR DESCRIPTION
Resolves issue mentioned as comment: https://github.com/voorhoede/riotjs-style-guide/pull/6#issuecomment-229688334
