### PR TITLE
fix links to CONTRIBUTING.md and ToC

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,6 @@ Resolves # .
 ## Checklist
 
 * [ ] The changes only affect or contain one style guide rule or section.
-* [ ] The changes are in [style guide format](/CONTRIBUTING.md#format).
-* [ ] The new style guide section has an entry in the [Table of Contents](/README.md#table-of-contents) (only if changes introduce new section).
+* [ ] The changes are in [style guide format](https://github.com/voorhoede/riotjs-style-guide/blob/master/CONTRIBUTING.md#format).
+* [ ] The new style guide section has an entry in the [Table of Contents](https://github.com/voorhoede/riotjs-style-guide/blob/master/README.md#table-of-contents) (only if changes introduce new section).
 * [ ] The changes can be merged into the target branch without conflicts. 


### PR DESCRIPTION
## Summary

Proposed changes:

Fix links to CONTRIBUTING.md and Table of Contents. The links were using "relative to root notation" (`/` prefix) causing them to point to `github.com/` instead of this repository.
## Checklist
- [X] The changes can be merged into the target branch without conflicts. 
