### PR TITLE
add note about serverside rendering in `.tag.html` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ In case you're using the [Webpack tag loader](https://github.com/srackham/tag-lo
 { test: /\.tag.html$/, loader: 'tag' }
 ```
 
+### Server Side rendering
+
+When requiring tags server side, there is no way (yet) to set custom extensions. There for, if you use server side rendering you either:
+
+* need to pre-compile your tags, so you can require the resulting `.js` files.
+* use the default `.tag` extension because Riot lets NodeJS require this extension by default.
+
 [↑ back to Table of Contents](#table-of-contents)
 
 


### PR DESCRIPTION
## Summary

Proposed changes:

* Add note aboute extensions in `.tag.html` rule as discussed in #57 

Resolves #57 .

## Checklist

* [x] The changes only affect or contain one style guide rule or section.
* [x] The changes are in [style guide format](https://github.com/voorhoede/riotjs-style-guide/blob/master/CONTRIBUTING.md#format).
* [ ] The new style guide section has an entry in the [Table of Contents](https://github.com/voorhoede/riotjs-style-guide/blob/master/README.md#table-of-contents) (only if changes introduce new section).
* [x] The changes can be merged into the target branch without conflicts. 

