### PR TITLE
Update link to "valid custom element name" spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Each module name must be:
 
 Tag module names must also be:
 
-* **Custom element spec compliant**: [include a hyphen](https://www.w3.org/TR/custom-elements/#concepts), don't use reserved names.
+* **Custom element spec compliant**: [include a hyphen](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name), don't use reserved names.
 * **`app-` namespaced**: if very generic and otherwise 1 word, so that it can easily be reused in other projects.
 
 ### Why?


### PR DESCRIPTION
## Summary

Proposed changes:

Update link to "valid custom element name" spec.
The old reference no longer exists.

## Checklist

* [x] The changes only affect or contain one style guide rule or section.
* [x] The changes are in [style guide format](https://github.com/voorhoede/riotjs-style-guide/blob/master/CONTRIBUTING.md#format).
* [x] The changes can be merged into the target branch without conflicts. 
